### PR TITLE
fix: print out the name of the browser during setup

### DIFF
--- a/src/runner.js
+++ b/src/runner.js
@@ -222,7 +222,7 @@ class Runner {
   }
 
   async run() {
-    let spinner = ora('Setting up browser').start()
+    let spinner = ora(`Setting up ${this.options.browser}`).start()
 
     try {
       // get the context
@@ -244,7 +244,7 @@ class Runner {
           'Uncaught exception happened within the page. Run with --debug.'
         )
       })
-      spinner.succeed('Browser setup')
+      spinner.succeed(`${this.options.browser} set up`)
 
       // bundle tests
       spinner = ora('Bundling tests').start()
@@ -309,7 +309,7 @@ class Runner {
   }
 
   async watch() {
-    const spinner = ora('Setting up browser').start()
+    const spinner = ora(`Setting up ${this.options.browser}`).start()
 
     const context = await this.launch()
     if (this.options.before) {


### PR DESCRIPTION
Since aegir went from `--browsers  FirefoxHeadless` to `--browser firefox` it's really easy to accidentally run tests in Chromium when you think you're running in Firefox.

The change here is just to print the name of the browser being used during the setup phase for a little sanity check.