### PR TITLE
fix: use random high port

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -497,7 +497,7 @@ function getPort(port = 3000, host = '127.0.0.1') {
  */
 export async function createPolka(runner) {
   const host = '127.0.0.1'
-  const port = await getPort(3000, host)
+  const port = await getPort(0, host)
   const url = `http://${host}:${port}/`
   return new Promise((resolve, reject) => {
     const { server } = polka()


### PR DESCRIPTION
When you have multiple test suites run in parallel I frequently see conflicts for port 3000. It looks like the code tries to handle that but I'm still seeing errors so I think there's a race condition here somewhere.

Instead, let's just use a random high port to start with.

Fixes these sorts of errors, that I see in CI, a lot:

```
lerna info Executing command in 4 packages: "npm run test:webworker -- --bail --timeout 60000 -- --browser firefox"
ipfs-http-client: > ipfs-http-client@50.1.2 test:webworker /home/travis/build/ipfs/js-ipfs/packages/ipfs-http-client
ipfs-http-client: > aegir test -t webworker "--bail" "--timeout" "60000" "--" "--browser" "firefox"
ipfs-message-port-protocol: > ipfs-message-port-protocol@0.7.3 test:webworker /home/travis/build/ipfs/js-ipfs/packages/ipfs-message-port-protocol
ipfs-message-port-protocol: > aegir test -t webworker "--bail" "--timeout" "60000" "--" "--browser" "firefox"
ipfs-message-port-protocol: Test Webworker
ipfs-http-client: Test Webworker
ipfs-message-port-protocol: - Setting up firefox
ipfs-http-client: listen EADDRINUSE: address already in use 127.0.0.1:3000
ipfs-http-client: npm ERR! code ELIFECYCLE
ipfs-http-client: npm ERR! errno 1
ipfs-http-client: npm ERR! ipfs-http-client@50.1.2 test:webworker: `aegir test -t webworker "--bail" "--timeout" "60000" "--" "--browser" "firefox"`
ipfs-http-client: npm ERR! Exit status 1
ipfs-http-client: npm ERR!
ipfs-http-client: npm ERR! Failed at the ipfs-http-client@50.1.2 test:webworker script.
ipfs-http-client: npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
ipfs-http-client: npm ERR! A complete log of this run can be found in:
ipfs-http-client: npm ERR!     /home/travis/.npm/_logs/2021-07-15T08_42_18_746Z-debug.log
lerna ERR! npm run test:webworker -- --bail --timeout 60000 -- --browser firefox exited 1 in 'ipfs-http-client'
lerna WARN complete Waiting for 1 child process to exit. CTRL-C to exit immediately.
```