### PR TITLE
fix: coverage entry paths

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -432,7 +432,7 @@ export async function createCov(runner, coverage, file) {
   const f = new Set(exclude.globSync().map((f) => path.resolve(f)))
 
   for (const entry of coverage) {
-    const filePath = path.join(runner.dir, entry.url.replace(runner.url, ''))
+    const filePath = path.resolve(entry.url.replace(runner.url, ''))
 
     if (filePath.includes(file)) {
       // @ts-ignore


### PR DESCRIPTION
When I use `playwright-test` with `uvu` on Node 14.17.0, Windows, the generated `.nyc_output/coverage-pw.json` is `{}`. Digging the bug, I found here, 

https://github.com/hugomrdias/playwright-test/blob/18d2f26c55fd1ac8e10249f23ceb9e4479e8b21f/src/utils/index.js#L432-L454

where `runner.dir` (L435) is a cache dir, and `f` (L432) resolves to the working dir. `V8ToIstanbul` (L439-L444) uses the former one so there's no way it will be the same as `f` in L448.

That's the problem.