### PR TITLE
fix: pass original paths to esbuild

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -392,7 +392,7 @@ require('${require
     mainFields: ['browser', 'module', 'main'],
     sourcemap: 'inline',
     plugins: [nodePlugin, watchPlugin],
-    outfile: outName,
+    outfile: path.join(runner.options.cwd, outName),
     write: false,
     inject: [path.join(__dirname, 'inject-process.js')],
     define: {
@@ -419,12 +419,12 @@ export async function createCov(runner, coverage, file) {
   const { cwd } = runner.options
   // @ts-ignore
   const TestExclude = require('test-exclude')
-  const exclude = new TestExclude()
+  const exclude = new TestExclude({ cwd })
   // @ts-ignore
-  const f = new Set(exclude.globSync().map((f) => path.resolve(f)))
+  const f = new Set(exclude.globSync().map((f) => path.join(cwd, f)))
 
   for (const entry of coverage) {
-    const filePath = path.resolve(entry.url.replace(runner.url, ''))
+    const filePath = path.join(cwd, entry.url.replace(runner.url, ''))
 
     if (filePath.includes(file)) {
       // @ts-ignore

--- a/test.js
+++ b/test.js
@@ -20,7 +20,7 @@ describe('mocha', function () {
     const cov = JSON.parse(
       fs.readFileSync('.nyc_output/coverage-pw.json', 'utf8')
     )
-    ok(cov[path.resolve('mocks/test.mocha.js')], 'test coverage')
+    ok(path.resolve('mocks/test.mocha.js') in cov, 'test coverage')
   })
 
   it('cwd', async () => {
@@ -48,7 +48,7 @@ describe('mocha', function () {
     const cov = JSON.parse(
       fs.readFileSync('mocks/.nyc_output/coverage-pw.json', 'utf8')
     )
-    ok(cov[path.resolve('mocks/test.mocha.js')], 'test coverage')
+    ok(path.resolve('mocks/test.mocha.js') in cov, 'test coverage')
   })
 
   it('with DEBUG=app', async () => {

--- a/test.js
+++ b/test.js
@@ -1,3 +1,5 @@
+import fs from 'fs'
+import path from 'path'
 import { ok, is } from 'uvu/assert'
 import execa from 'execa'
 
@@ -7,6 +9,46 @@ describe('mocha', function () {
 
     is(proc.exitCode, 0, 'exit code')
     ok(proc.stdout.includes('5 passing'), 'process stdout')
+  })
+
+  it('coverage', async () => {
+    const proc = await execa('./cli.js', ['mocks/test.mocha.js', '--cov'])
+
+    is(proc.exitCode, 0, 'exit code')
+    ok(proc.stdout.includes('5 passing'), 'process stdout')
+
+    const cov = JSON.parse(
+      fs.readFileSync('.nyc_output/coverage-pw.json', 'utf8')
+    )
+    ok(cov[path.resolve('mocks/test.mocha.js')], 'test coverage')
+  })
+
+  it('cwd', async () => {
+    const proc = await execa('./cli.js', [
+      'test.mocha.js',
+      '--cwd',
+      path.resolve('mocks'),
+    ])
+
+    is(proc.exitCode, 0, 'exit code')
+    ok(proc.stdout.includes('5 passing'), 'process stdout')
+  })
+
+  it('coverage with cwd', async () => {
+    const proc = await execa('./cli.js', [
+      'test.mocha.js',
+      '--cwd',
+      path.resolve('mocks'),
+      '--cov',
+    ])
+
+    is(proc.exitCode, 0, 'exit code')
+    ok(proc.stdout.includes('5 passing'), 'process stdout')
+
+    const cov = JSON.parse(
+      fs.readFileSync('mocks/.nyc_output/coverage-pw.json', 'utf8')
+    )
+    ok(cov[path.resolve('mocks/test.mocha.js')], 'test coverage')
   })
 
   it('with DEBUG=app', async () => {


### PR DESCRIPTION
Passing temporary paths to `esbuild` to build bundles seems not to be a good idea for two reasons:
1. `esbuild` accepts using strings as an entry ([`stdin`](https://esbuild.github.io/api/#stdin) option), so it's redundant to write the contents into a temporary file beforehand.
2. `esbuild` uses `outfile` to resolve some file paths like in [`sourceRoot`](https://esbuild.github.io/api/#source-root) option. It is an unnecessary burden for us to take all into account how `esbuild` uses this path in current / future versions. It's best to bundle normally (i.e., use original paths) before `esbuild` provides a dedicated option that transpiles the output into a path without using the path to resolve files.
\
This _has_ affected some like in [evanw/esbuild#1699](https://github.com/evanw/esbuild/issues/1699), and that's the reason I maked this PR as a "fix". I would like to fill an issue if you wonder how `playwright-test` can lead to these cases.

This PR
1. passes the raw entry file content to `esbuild`, and requires `esbuild` to resolve output based on the current working path instead of using external temporary absolute paths.
2. sets `esbuild`'s [`write`](https://esbuild.github.io/api/#write) to `false` and uses `fs` to write into the real file we use.
3. since `entryPoint` and `outPath` aren't consumed by `esbuild` after the previous steps, removed their checks in `watchPlugin`.
4. fixes #323.