### PR TITLE
fix: fix package exports field

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
   "type": "module",
   "main": "src/runner.js",
   "types": "dist/src/runner.d.ts",
-  "exports": "./index.js",
+  "exports": {
+    ".": "./src/runner.js",
+    "./package.json": "./package.json"
+  },
   "bin": {
     "playwright-test": "cli.js",
     "pw-test": "cli.js"
@@ -27,7 +30,6 @@
     "dist/src/types.d.ts",
     "static",
     "src",
-    "index.js",
     "cli.js"
   ],
   "keywords": [


### PR DESCRIPTION
fix #330, add `./src/runner.js` and `./package.json` to `exports` field, also remove `index.js` from `files` field as it does not exist.