### PR TITLE
chore(deps): move tape to dev-deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "source-map": "0.6.1",
     "stream-browserify": "^3.0.0",
     "strip-ansi": "^7.0.0",
-    "tape": "^5.2.2",
     "tempy": "^2.0.0",
     "test-exclude": "^6.0.0",
     "v8-to-istanbul": "^8.0.0"
@@ -89,6 +88,7 @@
     "hd-scripts": "^1.0.0",
     "mocha": "^9.1.3",
     "simple-git-hooks": "^2.6.1",
+    "tape": "^5.2.2",
     "uvu": "^0.5.1",
     "zora": "^4.0.2"
   },


### PR DESCRIPTION
It seems `tape` should not be a required dependency.

BTW I think better to be "optional peer", by using `peerDependenciesMeta`. Willing to fill another PR if you agree with that. :-)