### PR TITLE
feat: allow overriding coverage dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ coverage.lcov
 yarn-error.log
 dist
 .tmp
+.coverage

--- a/cli.js
+++ b/cli.js
@@ -145,6 +145,10 @@ sade2
     "Enable code coverage in istanbul format. Outputs '.nyc_output/coverage-pw.json'."
   )
   .option(
+    '--report-dir',
+    "Where to output code coverage in instanbul format.  (default '.nyc_output')"
+  )
+  .option(
     '--before',
     'Path to a script to be loaded on a separate tab before the main script.'
   )
@@ -219,6 +223,7 @@ sade2
           sw: opts.sw,
           node: opts.node,
           cov: opts.cov,
+          reportDir: opts['report-dir'],
           extensions: opts.extensions,
           beforeTests: opts.beforeTests,
           afterTests: opts.afterTests,

--- a/src/runner.js
+++ b/src/runner.js
@@ -297,7 +297,12 @@ export class Runner {
 
         // coverage
         if (this.options.cov && page.coverage) {
-          await createCov(this, await page.coverage.stopJSCoverage(), outName)
+          await createCov(
+            this,
+            await page.coverage.stopJSCoverage(),
+            outName,
+            this.options.reportDir ?? '.nyc_output'
+          )
         }
 
         // exit

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -18,6 +18,7 @@ export interface RunnerOptions {
   before?: string
   sw?: string
   cov: false
+  reportDir?: string
   extensions: string
   buildConfig: BuildOptions
   buildSWConfig: BuildOptions

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -409,12 +409,7 @@ require('${require
  * @param {string} file
  * @param {string} outputDir
  */
-export async function createCov(
-  runner,
-  coverage,
-  file,
-  outputDir = '.nyc_output'
-) {
+export async function createCov(runner, coverage, file, outputDir) {
   const spinner = ora('Generating code coverage.').start()
   const entries = {}
   const { cwd } = runner.options

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -407,8 +407,14 @@ require('${require
  * @param {import("../runner").Runner} runner
  * @param {any} coverage
  * @param {string} file
+ * @param {string} outputDir
  */
-export async function createCov(runner, coverage, file) {
+export async function createCov(
+  runner,
+  coverage,
+  file,
+  outputDir = '.nyc_output'
+) {
   const spinner = ora('Generating code coverage.').start()
   const entries = {}
   const { cwd } = runner.options
@@ -447,7 +453,7 @@ export async function createCov(runner, coverage, file) {
       }
     }
   }
-  const covPath = path.join(cwd, '.nyc_output')
+  const covPath = path.join(cwd, outputDir)
 
   await mkdir(covPath, { recursive: true })
 

--- a/test.js
+++ b/test.js
@@ -24,6 +24,24 @@ describe('mocha', function () {
     ok(path.resolve('mocks/test.mocha.js') in cov, 'test coverage')
   })
 
+  it('coverage with alternate report dir', async () => {
+    const proc = await execa('./cli.js', [
+      'mocks/test.mocha.js',
+      '--cov',
+      '--report-dir',
+      '.coverage',
+    ])
+
+    is(proc.exitCode, 0, 'exit code')
+    ok(proc.stdout.includes('5 passing'), 'process stdout')
+
+    const cov = JSON.parse(
+      // eslint-disable-next-line unicorn/prefer-json-parse-buffer
+      fs.readFileSync('.coverage/coverage-pw.json', 'utf8')
+    )
+    ok(path.resolve('mocks/test.mocha.js') in cov, 'test coverage')
+  })
+
   it('cwd', async () => {
     const proc = await execa('./cli.js', [
       'test.mocha.js',


### PR DESCRIPTION
Adds a `--report-dir` option that allows overriding the output dir for coverage reports.

This is to let tools like `codecov` automatically find coverage reports in situations that make it hard, if not impossible to configure discovery - e.g. monorepos with the GH `codecov-action`.