### PR TITLE
Allow newer playwright dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "ora": "^6.1.0",
     "p-wait-for": "5.0.0",
     "path-browserify": "^1.0.1",
-    "playwright-core": "1.29.0",
+    "playwright-core": "^1.29.0",
     "polka": "^0.5.2",
     "premove": "^4.0.0",
     "process": "^0.11.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,7 +26,7 @@ specifiers:
   ora: ^6.1.0
   p-wait-for: 5.0.0
   path-browserify: ^1.0.1
-  playwright-core: 1.29.0
+  playwright-core: ^1.29.0
   polka: ^0.5.2
   premove: ^4.0.0
   process: ^0.11.10


### PR DESCRIPTION
Pinning to an old version prevents us from testing newer browsers.