### PR TITLE
Support passing worker options for runners

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -140,6 +140,7 @@ sade2
   .option('-w, --watch', 'Watch files for changes and re-run tests.')
   .option('-i, --incognito', 'Use incognito window to run tests.')
   .option('-e, --extension', 'Use extension background_page to run tests.')
+  .option('-t, --type', 'Worker type.  (default classic)')
   .option(
     '--cov',
     "Enable code coverage in istanbul format. Outputs '.nyc_output/coverage-pw.json'."
@@ -233,6 +234,7 @@ sade2
           extensions: opts.extensions,
           beforeTests: opts.beforeTests,
           afterTests: opts.afterTests,
+          workerOptions: { type: opts.type || 'classic' },
         })
       )
 

--- a/mocks/test.mocha.mjs
+++ b/mocks/test.mocha.mjs
@@ -1,6 +1,6 @@
 /* eslint-disable no-undef */
 // eslint-disable-next-line strict
-import { is } from 'uvu/assert'
+import { is , ok } from 'uvu/assert'
 import debug from 'debug'
 import { good, bad } from './lib.js'
 
@@ -29,5 +29,11 @@ describe('Array', () => {
     it('should return "bad"', async () => {
       is(await bad(), 'bad')
     })
+  })
+})
+
+describe('import.meta.url works', () => { 
+  it('import.meta.url should be defined', () => {
+    ok(import.meta.url)
   })
 })

--- a/mocks/test.mocha.mjs
+++ b/mocks/test.mocha.mjs
@@ -1,0 +1,33 @@
+/* eslint-disable no-undef */
+// eslint-disable-next-line strict
+import { is } from 'uvu/assert'
+import debug from 'debug'
+import { good, bad } from './lib.js'
+
+debug('app')
+
+
+describe('Array', () => {
+  describe('#indexOf()', () => {
+    it('should return -1 when the value is not present', () => {
+      is([1, 2, 3].indexOf(4), -1)
+    })
+
+    it('should fail  ', () => {
+      is([1, 2, 3].indexOf(2), 1)
+    })
+
+    it('should pass with debug', () => {
+      is([1, 2, 3].indexOf(4), -1)
+      debug('test pass')
+    })
+
+    it('should return "good"', async () => {
+      is(await good(), 'good')
+    })
+
+    it('should return "bad"', async () => {
+      is(await bad(), 'bad')
+    })
+  })
+})

--- a/readme.md
+++ b/readme.md
@@ -34,6 +34,7 @@ Description
     -w, --watch        Watch files for changes and re-run tests.
     -i, --incognito    Use incognito window to run tests.
     -e, --extension    Use extension background_page to run tests.
+    -t, --type         Worker type.  (default classic)
     --cov              Enable code coverage in istanbul format. Outputs '.nyc_output/coverage-pw.json'.
     --before           Path to a script to be loaded on a separate tab before the main script.
     --sw               Path to a script to be loaded in a service worker.

--- a/src/runner.js
+++ b/src/runner.js
@@ -53,6 +53,7 @@ const defaultOptions = {
   buildConfig: {},
   buildSWConfig: {},
   browserContextOptions: {},
+  workerOptions: {},
   beforeTests: async () => {},
   afterTests: async () => {},
 }
@@ -233,7 +234,7 @@ export class Runner {
       }
       case 'worker': {
         // do not await for the promise because we will wait for the 'worker' event after
-        page.evaluate(addWorker(outName))
+        page.evaluate(addWorker(outName, this.options.workerOptions))
         break
       }
       default: {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -24,6 +24,7 @@ export interface RunnerOptions {
   buildConfig: BuildOptions
   buildSWConfig: BuildOptions
   browserContextOptions?: BrowserContextOptions
+  workerOptions?: WorkerOptions
   beforeTests: (opts: RunnerOptions) => Promise<unknown>
   afterTests: (
     opts: RunnerOptions,

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -266,10 +266,11 @@ export async function getPw(browserName) {
 
 /**
  * @param {string} filePath
+ * @param {WorkerOptions} options
  */
-export function addWorker(filePath) {
+export function addWorker(filePath, options = {}) {
   return `
-const w = new Worker("${filePath}");
+const w = new Worker("${filePath}",${JSON.stringify(options)});
 w.onmessage = function(e) {
     if(e.data.pwRunEnded) {
         self.PW_TEST.end(e.data.pwRunFailed)
@@ -302,6 +303,7 @@ export function runnerOptions(flags) {
       'node',
       'cov',
       'config',
+      'type',
       '_',
       'd',
       'r',
@@ -310,6 +312,7 @@ export function runnerOptions(flags) {
       'w',
       'i',
       'e',
+      't',
     ]
 
     if (!localFlags.includes(key)) {
@@ -388,6 +391,7 @@ require('${require
       contents: infileContent,
       resolveDir: runner.options.cwd,
     },
+    format: runner.options.workerOptions?.type === 'module' ? 'esm' : 'iife',
     // sourceRoot: runner.dir,
     bundle: true,
     sourcemap: 'inline',

--- a/test.js
+++ b/test.js
@@ -99,6 +99,18 @@ describe('mocha', function () {
     is(proc.exitCode, 0, 'exit code')
     ok(proc.stdout.includes('5 passing'), 'process stdout')
   })
+  it('mode:worker with type: "module"', async () => {
+    const proc = await execa('./cli.js', [
+      'mocks/test.mocha.mjs',
+      '--mode',
+      'worker',
+      '--type',
+      'module',
+    ])
+
+    is(proc.exitCode, 0, 'exit code')
+    ok(proc.stdout.includes('5 passing'), 'process stdout')
+  })
 
   it('mocha extension', async () => {
     const proc = await execa('./cli.js', ['mocks/test.mocha.js', '--extension'])


### PR DESCRIPTION
related #530 

I have a use case where I need `import.meta.url` to work inside a worker, for that I need worker environment to be ESM. I've added `workerOptions` setting for runners and a `--type` flag (aka `Worker(url, { type: 'module' })`.

Test fails for `import.meta.url` but doesn't report any error, it just throws. Assistance would be appreciated :3