### PR TITLE
feat!: external runner support

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -214,10 +214,6 @@ sade2
           TestRunner = NoneRunner
           break
         }
-        case 'subtest': {
-          TestRunner = SubtestRunner
-          break
-        }
 
         default: {
           TestRunner = await Runner.import(opts.runner)

--- a/cli.js
+++ b/cli.js
@@ -13,6 +13,7 @@ import MochaRunner from './src/runner-mocha.js'
 import TapeRunner from './src/runner-tape.js'
 import { BenchmarkRunner } from './src/runner-benchmark.js'
 import ZoraRunner from './src/runner-zora.js'
+import { Runner } from './src/runner.js'
 import fs from 'fs'
 import { NoneRunner } from './src/runner-none.js'
 
@@ -186,40 +187,49 @@ sade2
         config.config = await config.config()
       }
 
-      let Runner
+      let TestRunner
 
       switch (opts.runner) {
         case 'uvu': {
-          Runner = UvuRunner
+          TestRunner = UvuRunner
           break
         }
         case 'zora': {
-          Runner = ZoraRunner
+          TestRunner = ZoraRunner
           break
         }
         case 'mocha': {
-          Runner = MochaRunner
+          TestRunner = MochaRunner
           break
         }
         case 'tape': {
-          Runner = TapeRunner
+          TestRunner = TapeRunner
           break
         }
         case 'benchmark': {
-          Runner = BenchmarkRunner
+          TestRunner = BenchmarkRunner
           break
         }
         case 'none': {
-          Runner = NoneRunner
+          TestRunner = NoneRunner
+          break
+        }
+        case 'subtest': {
+          TestRunner = SubtestRunner
           break
         }
 
         default: {
-          console.error('Runner not supported:', opts.runner)
-          process.exit(1)
+          TestRunner = await Runner.import(opts.runner)
         }
       }
-      const runner = new Runner(
+
+      if (!TestRunner) {
+        console.error('Runner not supported:', opts.runner)
+        process.exit(1)
+      }
+
+      const runner = new TestRunner(
         merge(config ? config.config : {}, {
           cwd: opts.cwd,
           assets: opts.assets,

--- a/src/runner.js
+++ b/src/runner.js
@@ -71,7 +71,9 @@ export class Runner {
     try {
       const path = resolveModule(id)
       const module = await import(path)
-      return /** @type {Runner} */ (module.createPlaywrightRunner(Runner))
+      return /** @type {typeof Runner} */ (
+        module.createPlaywrightRunner(Runner)
+      )
     } catch {}
   }
 

--- a/src/runner.js
+++ b/src/runner.js
@@ -447,7 +447,7 @@ export class Runner {
   }
 
   /**
-   * @param {ESBuildOptions} config - Runner esbuild config
+   * @param {import('esbuild').BuildOptions} config - Runner esbuild config
    * @param {string} tmpl
    * @param {"bundle" | "before" | "watch"} mode
    */

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -346,9 +346,7 @@ process.env = ${JSON.stringify(runner.env)}
 
 ${tmpl}
 
-${runner.tests
-  .map((t) => `await import('${t.replace(/\\/g, '/')}')`)
-  .join('\n')}
+${runner.compileTestImports(runner.tests.map((t) => t.replace(/\\/g, '/')))}
 `
 
   // before script template
@@ -466,6 +464,23 @@ export async function createCov(runner, coverage, file, outputDir) {
   )
   spinner.succeed('Code coverage generated, run "npx nyc report".')
 }
+
+/**
+ * Resolves module id from give base or cwd
+ *
+ * @param {string} id - module id
+ * @param {string} [base=process.cwd()] - base path
+ */
+export const resolveModule = (id, base = toDirectoryPath(process.cwd())) =>
+  createRequire(base).resolve(id)
+
+/**
+ * Ensures that path ends with a path separator
+ *
+ * @param {string} source
+ */
+export const toDirectoryPath = (source) =>
+  source.endsWith(path.sep) ? source : `${source}${path.sep}`
 
 /**
  * Get a free port


### PR DESCRIPTION
This PR adds support for external runners by providing a module id to the `--runner` option. When such option (different from built-in runner id) is provided it will attempt to load the module and obtain a `Runner` by calling `createPlaywrightRunner` function.

This allows test frameworks to integrate with `playwright-test` without having to send PRs for their custom runners.

For example https://github.com/Gozala/subtest runner adds such integration in this PR https://github.com/Gozala/subtest/pull/6/files#diff-8fa1eed146d55d81bf2df786a637b04be2a53bcdc17791ccf36dbe03a025c87e and allows me to run tests in playwright by calling

```
playwright-test test --runner @gozala/subtest test
```

Here is example of such a run https://github.com/Gozala/subtest/actions/runs/5283504801/jobs/9559839639 which playwright-test with proposed changes

## Additional changes

- I've added `build` method to the runner, so that test framework can define custom runner without introducing dependency on `playwright-test` as it could introduce dependency hell.
- I have refactored build logic to allow runner to decorate test imports. In my concrete use case, my test modules do not import any test framework and therefor runner needs reference to them to run. Which becomes possible with `compileTestImports` method on the runner, which by default does what build script did before.