### PR TITLE
fix: test for skipped browser warnings early

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -260,6 +260,17 @@ export async function redirectConsole(msg) {
     return
   }
   const text = msg.text()
+
+  // skip browser informational warnings
+  if (
+    text?.includes(
+      'Synchronous XMLHttpRequest on the main thread is deprecated'
+    ) ||
+    text?.includes('Clear-Site-Data')
+  ) {
+    return
+  }
+
   // const { url, lineNumber, columnNumber } = msg.location()
   let msgArgs
 
@@ -274,14 +285,6 @@ export async function redirectConsole(msg) {
   if (msgArgs && msgArgs.length > 0) {
     consoleFn.apply(console, msgArgs)
   } else if (text) {
-    if (
-      text.includes(
-        'Synchronous XMLHttpRequest on the main thread is deprecated'
-      ) ||
-      text.includes('Clear-Site-Data')
-    ) {
-      return
-    }
     console.error(kleur.dim(`🌐${text}`))
   }
 }


### PR DESCRIPTION
# Description

Some browser warning logs are skipped - moves the test for the skippable warnings earlier in the method as they aren't skipped if valid message args are extracted from the message.

## Link to issue

https://github.com/libp2p/test-plans/pull/361

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Refactor (non-breaking change that updates existing functionality)
- [x] Comments have been added/updated
