### PR TITLE
fix: log playwright browser download progress on stderr

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -304,7 +304,19 @@ export async function getPw(browserName) {
   const api = await import('playwright-core')
   const browser = registry.findExecutable(browserName)
 
-  await registry.install([browser])
+  // playwright will log browser download progress to stdout, temporarily
+  // redirect the output to stderr
+  const log = console.log
+  const info = console.info
+
+  try {
+    console.log = console.error
+    console.info = console.error
+    await registry.install([browser])
+  } finally {
+    console.log = log
+    console.info = info
+  }
 
   return api[browserName]
 }


### PR DESCRIPTION
If a browser is downloaded during a test run, playwright will log on stdout.

This can interfere with the calling code if it's trying to parse the output of the program as, for example, JSON.

The fix is to temporarily replace `console.log` with `console.error` as that's what the [logPolitely](https://github.com/microsoft/playwright/blob/718bd9b35fd206245401a9ecb320289f427592d9/packages/playwright-core/src/server/registry/browserFetcher.ts#L120) function uses to give feedback to the user.

The intention of the playwright maintainers is [not for this functionality to be used during a test run](https://github.com/microsoft/playwright/issues/32487#issuecomment-2337666079) so it's unlikely to move to stderr otherwise.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor (non-breaking change that updates existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Comments have been added/updated
