### PR TITLE
fix: pass channel to playwright

### DIFF
--- a/src/runner.js
+++ b/src/runner.js
@@ -99,6 +99,7 @@ export class Runner {
 
     /** @type {import('playwright-core').LaunchOptions} */
     const pwOptions = {
+      channel: this.options.browser,
       headless: !this.options.debug,
       devtools: this.options.browser === 'chromium' && this.options.debug,
       args: this.options.extension


### PR DESCRIPTION
The 1.49.0 release of playwright has a breaking change due to a new version of headless mode in chromium.

The upshot is that playwright now seems to require a channel to be passed in it's config.

Without this chrome test runs fail with:

```
 browserType.launchPersistentContext: Executable doesn't exist at /home/runner/.cache/ms-playwright/chromium_headless_shell-1148/chrome-linux/headless_shell
```

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor (non-breaking change that updates existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Comments have been added/updated
