### PR TITLE
deps: bump to playwright 1.60.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
 		"ora": "^9.0.0",
 		"p-timeout": "^6.1.4",
 		"path-browserify": "^1.0.1",
-		"playwright-core": "1.58.2",
+		"playwright-core": "1.60.0",
 		"polka": "^0.5.2",
 		"premove": "^4.0.0",
 		"process": "^0.11.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,8 +66,8 @@ importers:
         specifier: ^1.0.1
         version: 1.0.1
       playwright-core:
-        specifier: 1.58.2
-        version: 1.58.2
+        specifier: 1.60.0
+        version: 1.60.0
       polka:
         specifier: ^0.5.2
         version: 0.5.2
@@ -820,11 +820,12 @@ packages:
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   globalthis@1.0.4:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
@@ -1222,8 +1223,8 @@ packages:
   platform@1.3.6:
     resolution: {integrity: sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==}
 
-  playwright-core@1.58.2:
-    resolution: {integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==}
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -2672,7 +2673,7 @@ snapshots:
 
   platform@1.3.6: {}
 
-  playwright-core@1.58.2: {}
+  playwright-core@1.60.0: {}
 
   polka@0.5.2:
     dependencies:

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -305,8 +305,9 @@ export async function getPw(browserName, debug, extension) {
   }
 
   // @ts-ignore
-  const { registry } = await import('playwright-core/lib/server')
+  const { registry: registryExports } = await import('playwright-core/lib/coreBundle')
   const api = await import('playwright-core')
+  const { registry } = registryExports
   const browser = registry.findExecutable(browserName)
 
   // playwright will log browser download progress to stdout, temporarily


### PR DESCRIPTION
# Description

Bump playwright to 1.60.0 and fix package import

```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './lib/server' is not defined by "exports" in /home/runner/work/js-libp2p/js-libp2p/node_modules/playwright-core/package.json imported from /home/runner/work/js-libp2p/js-libp2p/node_modules/playwright-test/src/utils/index.js
```

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
